### PR TITLE
Trim leading zeros from time

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -37,6 +37,9 @@ function parseTracks(str) {
         if (track.title.match(trackTimeRegex)) {
             track.time = trackTimeRegex.exec(track.title)[0];
             track.title = track.title.replace(track.time, '').trim();
+
+            // Trim off any leading zeros from the time (ie. '01:23' -> '1:23').
+            track.time = track.time.replace(/^[0:]+/g, '');
         }
 
         // Strip surrounding "".

--- a/parse.test.js
+++ b/parse.test.js
@@ -83,6 +83,19 @@ var tests = [
             {number: '2', title: 'Diamonds (featuring Solomon Grey)', time: '5:54'},
         ],
     },
+    {
+        str: `
+        1. Loving You (featuring Lulu James) (0:00)
+        2. Diamonds (featuring Solomon Grey) (01:23)
+        3. Pearls                            (0:00:00)
+        4. Emeralds                          (1:00:00)`,
+        expected: [
+            {number: '1', title: 'Loving You (featuring Lulu James)', time: ''},
+            {number: '2', title: 'Diamonds (featuring Solomon Grey)', time: '1:23'},
+            {number: '3', title: 'Pearls', time: ''},
+            {number: '4', title: 'Emeralds', time: '1:00:00'},
+        ],
+    },
 ];
 
 function clean(tracks) {
@@ -90,7 +103,7 @@ function clean(tracks) {
         number: track.number,
         title: track.title,
         time: track.time,
-    })))
+    })), null, 2)
 }
 
 tests.forEach(test => {


### PR DESCRIPTION
For example, '01:23' to '1:23'. This also replaced zero times with an
empty time field: '0:00' -> ''.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/tracklist-editor/1)
<!-- Reviewable:end -->
