### PR TITLE
Added line mode when track is spread on multiple lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,11 @@
                     newTrackNumber: '',
                     newTrackTitle: '',
                     newTrackTime: '',
+                    lineMode: 'one-line',
                 },
                 methods: {
                     parse() {
-                        this.tracks = parseTracks(this.rawTrackList);
+                        this.tracks = parseTracks(this.rawTrackList, this.lineMode);
                         bootstrap.Modal.getInstance(document.getElementById('newModal')).hide();
                     },
                     renderHighlight(title, ranges) {
@@ -295,9 +296,14 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        Track Editor will do its best to decipher whatever input you give it. The only important thing
-                        to note is that it will expect there to be one track per line and will ignore blank
-                        lines.<br /><br />
+                        Track Editor will do its best to decipher whatever input you give it.
+                        <br /><br />
+                        <select class="form-select" aria-label="Line mode" v-model="lineMode">
+                          <option value="one-line" selected>One line per track</option>
+                          <option value="artist-first">Two lines per track (artist first)</option>
+                          <option value="title-first">Two lines per track (title first)</option>
+                        </select>
+                        <br />
                         <textarea class="form-control" id="rawTrackList" rows="10"
                             style="font-family: 'Courier New', Courier, monospace;" v-model="rawTrackList"></textarea>
                     </div>

--- a/parse.js
+++ b/parse.js
@@ -15,10 +15,26 @@ function newTrack(track) {
     }
 }
 
-function parseTracks(str) {
-    const lines = str.split('\n').filter(x => x.trim() !== '');
+function parseTracks(str, lineMode) {
+    let lines = str.split('\n').filter(x => x.trim() !== '');
     const trackNumberRegex = /^\d+[.-\s|]*/;
     const trackTimeRegex = /(\d+:)?\d+:\d\d/;
+
+    if (lineMode === 'artist-first') {
+        let newLines = [];
+        for (let i = 0; i < lines.length; i += 2) {
+            newLines.push(lines[i] + ' - ' + lines[i+1])
+        }
+        lines = newLines;
+    }
+
+    if (lineMode === 'title-first') {
+        let newLines = [];
+        for (let i = 0; i < lines.length; i += 2) {
+            newLines.push(lines[i+1] + ' - ' + lines[i])
+        }
+        lines = newLines;
+    }
 
     const tracks = lines.map((line, i) => {
         let track = {

--- a/parse.test.js
+++ b/parse.test.js
@@ -1,24 +1,45 @@
 const parseTracks = require('./parse');
 
 var tests = [
-    {str: '', expected: []},
-    {str: 'you can leave your hat on', expected: [
-        {number: '', title: 'you can leave your hat on', time: ''},
-    ]},
-    {str: 'you can leave your hat on\n', expected: [
-        {number: '', title: 'you can leave your hat on', time: ''},
-    ]},
-    {str: '\n\nyou can leave your hat on\n', expected: [
-        {number: '', title: 'you can leave your hat on', time: ''},
-    ]},
-    {str: 'track 1\ntrack 2\n', expected: [
-        {number: '', title: 'track 1', time: ''},
-        {number: '', title: 'track 2', time: ''},
-    ]},
+    {
+        str: '',
+        lineMode: 'one-line',
+        expected: [],
+    },
+    {
+        str: 'you can leave your hat on',
+        lineMode: 'one-line',
+        expected: [
+            {number: '', title: 'you can leave your hat on', time: ''},
+        ],
+    },
+    {
+        str: 'you can leave your hat on\n',
+        lineMode: 'one-line',
+        expected: [
+            {number: '', title: 'you can leave your hat on', time: ''},
+        ],
+    },
+    {
+        str: '\n\nyou can leave your hat on\n',
+        lineMode: 'one-line',
+        expected: [
+            {number: '', title: 'you can leave your hat on', time: ''},
+        ],
+    },
+    {
+        str: 'track 1\ntrack 2\n',
+        lineMode: 'one-line',
+        expected: [
+            {number: '', title: 'track 1', time: ''},
+            {number: '', title: 'track 2', time: ''},
+        ],
+    },
     {
         str: `
         1	Next to Me	 	 	5:14
         2	Make It Happen	5:20`,
+        lineMode: 'one-line',
         expected: [
             {number: '1', title: 'Next to Me', time: '5:14'},
             {number: '2', title: 'Make It Happen', time: '5:20'},
@@ -28,6 +49,7 @@ var tests = [
         str: `
         1.	"Next to Me"	 	 	5:14
         2.	"Make It Happen"	5:20`,
+        lineMode: 'one-line',
         expected: [
             {number: '1', title: 'Next to Me', time: '5:14'},
             {number: '2', title: 'Make It Happen', time: '5:20'},
@@ -37,6 +59,7 @@ var tests = [
         str: `
         1 -	Next to  \t  Me
         2 - Make\tIt Happen`,
+        lineMode: 'one-line',
         expected: [
             {number: '1', title: 'Next to Me', time: ''},
             {number: '2', title: 'Make It Happen', time: ''},
@@ -47,6 +70,7 @@ var tests = [
         First track (1:23)
         Second track (45:57)
         Third track (8:12:34)`,
+        lineMode: 'one-line',
         expected: [
             {number: '', title: 'First track', time: '1:23'},
             {number: '', title: 'Second track', time: '45:57'},
@@ -58,6 +82,7 @@ var tests = [
         First track - 1:23
         Second track - 45:57
         Third track - 8:12:34`,
+        lineMode: 'one-line',
         expected: [
             {number: '', title: 'First track', time: '1:23'},
             {number: '', title: 'Second track', time: '45:57'},
@@ -69,6 +94,7 @@ var tests = [
         str: `
         Artist 1 — First track
         Artist 2 — Second track`,
+        lineMode: 'one-line',
         expected: [
             {number: '', title: 'Artist 1 - First track', time: ''},
             {number: '', title: 'Artist 2 - Second track', time: ''},
@@ -78,6 +104,7 @@ var tests = [
         str: `
         1|Loving You (featuring Lulu James)|4:01
         2|Diamonds (featuring Solomon Grey)|5:54`,
+        lineMode: 'one-line',
         expected: [
             {number: '1', title: 'Loving You (featuring Lulu James)', time: '4:01'},
             {number: '2', title: 'Diamonds (featuring Solomon Grey)', time: '5:54'},
@@ -89,11 +116,48 @@ var tests = [
         2. Diamonds (featuring Solomon Grey) (01:23)
         3. Pearls                            (0:00:00)
         4. Emeralds                          (1:00:00)`,
+        lineMode: 'one-line',
         expected: [
             {number: '1', title: 'Loving You (featuring Lulu James)', time: ''},
             {number: '2', title: 'Diamonds (featuring Solomon Grey)', time: '1:23'},
             {number: '3', title: 'Pearls', time: ''},
             {number: '4', title: 'Emeralds', time: '1:00:00'},
+        ],
+    },
+    {
+        str: `
+        Artist 1
+        First track
+        Artist 2
+        Second track`,
+        lineMode: 'artist-first',
+        expected: [
+            {number: '', title: 'Artist 1 - First track', time: ''},
+            {number: '', title: 'Artist 2 - Second track', time: ''},
+        ],
+    },
+    {
+        str: `
+        First track
+        Artist 1
+        Second track
+        Artist 2`,
+        lineMode: 'title-first',
+        expected: [
+            {number: '', title: 'Artist 1 - First track', time: ''},
+            {number: '', title: 'Artist 2 - Second track', time: ''},
+        ],
+    },
+    {
+        str: `
+        Artist 1
+        First track (1:23)
+        Artist 2
+        Second track (4:56)`,
+        lineMode: 'artist-first',
+        expected: [
+            {number: '', title: 'Artist 1 - First track', time: '1:23'},
+            {number: '', title: 'Artist 2 - Second track', time: '4:56'},
         ],
     },
 ];
@@ -107,7 +171,7 @@ function clean(tracks) {
 }
 
 tests.forEach(test => {
-    const actual = clean(parseTracks(test.str));
+    const actual = clean(parseTracks(test.str, test.lineMode));
     const expected = clean(test.expected);
     if (actual !== expected) {
         throw new Error(`expecting ${expected} but got ${actual}`)


### PR DESCRIPTION
Sometimes when pasting copied track lists the artists appear before or
after the track name which leads to double the lines when pasted. Now
there is an option for when pasting to deal with these.

Fixes #6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/tracklist-editor/7)
<!-- Reviewable:end -->
